### PR TITLE
Remove sudo call from artisan config:cache.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - composer dump-autoload
   - sudo chgrp -R www-data storage bootstrap/cache
   - sudo chmod -R ug+rwx storage bootstrap/cache
-  - sudo php artisan config:cache
+  - php artisan config:cache
   - nvm install 6.10.3
   - npm install npm@latest -g
   - npm install -g yarn


### PR DESCRIPTION
Builds are failing on this, and its because php is not found when executed as sudo. We will fix this hopefuly by calling it as the normal user.