### PR TITLE
app.js: When I switched to getting the token using jQuery

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -137,7 +137,7 @@ import 'bootstrap-material-design';
   // Set up CSRF token from meta tag for Axios AJAX requests
 
   if (token) {
-    axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;
+    axios.defaults.headers.common['X-CSRF-TOKEN'] = token;
   } else {
     console.error('CSRF token not found.');
   }


### PR DESCRIPTION
I just grabbed the actual token content instead of the element. I forgot to update setting the header and was still trying to access content property which was undefined.

Fixes error when sending axios AJAX requests.