### PR TITLE
Feature: Refactor LastModified service.

### DIFF
--- a/app/Providers/LastModifiedServiceProvider.php
+++ b/app/Providers/LastModifiedServiceProvider.php
@@ -2,27 +2,11 @@
 
 namespace App\Providers;
 
-use Carbon\Carbon;
-use RecursiveIteratorIterator;
-use RecursiveDirectoryIterator;
+use App\Services\LastModified;
 use Illuminate\Support\ServiceProvider;
 
 class LastModifiedServiceProvider extends ServiceProvider
 {
-    /**
-     * List of excluded directories when traversing application folders.
-     *
-     * @var array
-     */
-    private $excludedDirectories = [
-        'vendor',
-        'node_modules',
-        'tmp',
-        'storage',
-        'tests',
-        'cache',
-    ];
-
     /**
      * Register the application services.
      *
@@ -30,30 +14,8 @@ class LastModifiedServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind('lastModified', function () {
-            return $this->getLastModifiedDate();
+        $this->app->singleton('lastModified', function ($app) {
+            return new LastModified($app, $app['cache.store']);
         });
-    }
-
-    /**
-     * Function to get the last modified file time for the web application directory.
-     *
-     * @return \Carbon\Carbon
-     */
-    protected function getLastModifiedDate()
-    {
-        date_default_timezone_set(config('app.timezone'));
-
-        $timeStamp = null;
-
-        $directories = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->app->basePath()));
-
-        foreach ($directories as $path => $object) {
-            if (! in_array(basename($path), $this->excludedDirectories, true)) {
-                $timeStamp = filemtime($path) > $timeStamp ? filemtime($path) : $timeStamp;
-            }
-        }
-
-        return Carbon::createFromTimestamp($timeStamp);
     }
 }

--- a/app/Services/LastModified.php
+++ b/app/Services/LastModified.php
@@ -8,7 +8,6 @@ use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
-use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 
 class LastModified
 {

--- a/app/Services/LastModified.php
+++ b/app/Services/LastModified.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Services;
+
+use DirectoryIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Carbon\Carbon;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+
+class LastModified
+{
+    /**
+     * Application instance.
+     *
+     * @var \Illuminate\Contracts\Foundation\Application
+     */
+    private $app;
+    /**
+     * Application cache store.
+     *
+     * @var \Illuminate\Contracts\Cache\Repository
+     */
+    private $cache;
+
+    /**
+     * List of directories to traverse to determine last modified file time.
+     * This array is built in the function {@link buildIncludedDirectoies}.
+     *
+     * @var array
+     */
+    private $includedDirectories = [];
+
+    /**
+     * Constructs a LastModified service object.
+     *
+     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param \Illuminate\Contracts\Cache\Repository       $cache
+     */
+    public function __construct(Application $app, CacheRepository $cache)
+    {
+        $this->app = $app;
+        $this->cache = $cache;
+        $this->buildIncludedDirectories();
+    }
+
+    /**
+     * [buildIncludedDirectories description]
+     *
+     * @return void
+     */
+    private function buildIncludedDirectories()
+    {
+        $appPath = $this->app->make('path');
+        $configPath = $this->app->make('path.config');
+        $publicPath = $this->app->make('path.public');
+        $databasePath = $this->app->make('path.database');
+        $resourcePath = $this->app->make('path.resources');
+        $bootstrapPath = $this->app->make('path.bootstrap');
+        $testPath = $this->app->make('path.base').DIRECTORY_SEPARATOR.'tests';
+
+        $this->includedDirectories = [
+            $appPath,
+            $configPath,
+            $publicPath,
+            $databasePath,
+            $resourcePath,
+            $bootstrapPath,
+            $testPath,
+        ];
+    }
+
+    /**
+     * Function to get the last modified file time for the web application directory.
+     *
+     * @return \Carbon\Carbon
+     */
+    public function getLastModifiedFile()
+    {
+        $timestamp = null;
+
+        if ($this->cache->has('lastModifiedTime')) {
+            $timestamp = $this->cache->get('lastModifiedTime');
+        } else {
+            foreach ($this->includedDirectories as $directory) {
+                $dir = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory));
+
+                foreach ($dir as $file) {
+                    if (! $file->isDir()) {
+                        $mTime = $file->getMTime();
+                        $timestamp = $mTime > $timestamp ? $mTime : $timestamp;
+                    }
+                }
+            }
+
+            $basePath = new DirectoryIterator($this->app->make('path.base'));
+
+            foreach ($basePath as $file) {
+                if (! $file->isDir()) {
+                    $mTime = $file->getMTime();
+                    $timestamp = $mTime > $timestamp ? $mTime : $timestamp;
+                }
+            }
+
+            $this->cache->put('lastModifiedTime', $timestamp, 30);
+        }
+
+        return Carbon::createFromTimestamp($timestamp);
+    }
+}

--- a/app/Services/LastModified.php
+++ b/app/Services/LastModified.php
@@ -2,12 +2,13 @@
 
 namespace App\Services;
 
-use DirectoryIterator;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 use Carbon\Carbon;
+use DirectoryIterator;
+use RecursiveIteratorIterator;
+use RecursiveDirectoryIterator;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 
 class LastModified
 {
@@ -46,7 +47,8 @@ class LastModified
     }
 
     /**
-     * [buildIncludedDirectories description]
+     * Function to populate {@link $this->includedDirectories} with the
+     * directories to consider for the last modified file time.
      *
      * @return void
      */

--- a/resources/views/partials/footer-base.blade.php
+++ b/resources/views/partials/footer-base.blade.php
@@ -43,7 +43,7 @@
         </div>
         <div id="copyright" class="copyright">
           Copyright &copy; 2017{{ intval(date('Y')) > 2017 ? '-'.date('Y') : '' }} Brandon Clothier
-          <br />Website last updated {{ app('lastModified')->format('F jS, Y \a\t h:i:s A T') }}
+          <br />Website last updated {{ app('lastModified')->getLastModifiedFile()->format('F jS, Y \a\t h:i:s A T') }}
           <br />Website Version: {{ config('app.version') }}
         </div>
       </div>


### PR DESCRIPTION
I took a naive approach to get the last modifed file time for my application directory. This recursed the whole project structure (including the git directory, node_modules, vendor, etc) and then I filtered out some of the directories I didn't want to take into account on the last modified time.

Also having the service bound as a function made it execute twice, once during bootstrapping and another whenit was actually used.

This function had around a half a second run time on my local machine which is way to much.

So my new approach was to first specify a list of directories to traverse. This includes the app folder, bootstrap, config, database, public, resources and the tests folders. I had to have a separate case to handle top level files in the base path, since using the RecursiveDirectoryIterator on the base path would lead to recursing down all folders like before. So for each directory specified I recurse into it and compare all file MTimes using the SplFileInfo objects. I then use a DirectoryIterator on the base path and get the top level files and compare them. Once I have the greatest file modified time, I cache that result for 30 minutes and reutrn the Carbon instance.

Without factoring in the caching, this algorithm went from 1/2 second to around 5ms. With caching in place (file caching driver on local machine) we are in the 0.3ms range. Much much better.

Plus the service is now in a class, which will make testing it easier. I was going to use the Laravel Filesystem object, but I had to many issues controlling the directory recursion, and I can test this using vfsStream to mock out the filesystem hopefully.